### PR TITLE
Fix: toggle script launching multiple instances and permission freeze

### DIFF
--- a/game-launcher/toggle.sh
+++ b/game-launcher/toggle.sh
@@ -3,7 +3,7 @@
 # This script toggles the game launcher visibility
 
 LAUNCHER_DIR="$HOME/.config/quickshell/game-launcher"
-PID_FILE="/tmp/quickshell-game-launcher.pid"
+PID_FILE="$HOME/.cache/quickshell-game-launcher.pid"
 
 # Check if launcher is running
 if [ -f "$PID_FILE" ]; then
@@ -14,13 +14,11 @@ if [ -f "$PID_FILE" ]; then
         # Kill the launcher
         kill "$PID"
         pkill -f "gamepad.py" || true
-        rm "$PID_FILE"
-        quickshell -c "$LAUNCHER_DIR" &
-        echo $! > "$PID_FILE"
+        rm -f "$PID_FILE"
         exit 0
     else
         # PID file exists but process is dead, clean up
-        rm "$PID_FILE"
+        rm -f "$PID_FILE"
     fi
 fi
 


### PR DESCRIPTION
Fixes two bugs in toggle.sh that broke the toggle behavior and caused the script to hang.

**What was fixed**

- The script was restarting the process instead of closing it. Fixed by removing the startup command from the shutdown block.

- The PID file in /tmp could end up owned by root, causing rm to prompt for confirmation and hang forever on every hotkey press. Moved it to ~/.cache/ for proper user permissions and added -f to rm to skip any future prompts.