### PR TITLE
Fix: PID-based toggle, hardcoded paths, and terminal detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Game launcher with multi-platform support and a sleek animated interface.
 
 ## 🎮 Gamepad
 
-| Bouton | Action |
+| Button | Action |
 |--------|--------|
-| ![](https://img.shields.io/badge/D--pad-grey?style=flat-square) | Naviguer dans la grille |
-| ![](https://img.shields.io/badge/A-1d7b36?style=flat-square&logo=xbox&logoColor=white) | Lancer le jeu sélectionné |
-| ![](https://img.shields.io/badge/B-c0392b?style=flat-square&logo=xbox&logoColor=white) | Fermer |
+| ![](https://img.shields.io/badge/D--pad-grey?style=flat-square) | Navigate the grid |
+| ![](https://img.shields.io/badge/A-1d7b36?style=flat-square&logo=xbox&logoColor=white) | Launch selected game |
+| ![](https://img.shields.io/badge/B-c0392b?style=flat-square&logo=xbox&logoColor=white) | Close |
 
 ## 🛠️ Installation
 
@@ -79,14 +79,14 @@ yay -S ttf-font-awesome-7
 ### Hyprland keybind
 
 In `~/.config/hypr/hyprland.conf`:
-Exemple:
+Example:
 ```conf
 bind = SUPER, G, exec, ~/.config/quickshell/game-launcher/toggle.sh
 ```
-Or
+<!-- Or
 ```conf
 bind = SUPER, G, exec, quickshell-game
-```
+``` -->
 
 ---
 

--- a/game-launcher/config.toml
+++ b/game-launcher/config.toml
@@ -114,6 +114,6 @@ ease_type = "OutCubic"
 box_art_dir = "~/.config/quickshell/game-launcher/box-art"
 
 [[entries]]
-title = "📚 Game Library"
-launch_command = "kitty -e python3 /home/florian/.config/quickshell/game-launcher/modules/service/list_games.py"
+title = "Game Library"
+launch_command = "~/.config/quickshell/game-launcher/modules/service/run_in_terminal.sh python3 ~/.config/quickshell/game-launcher/modules/service/list_games.py"
 path_box_art = "library.png"

--- a/game-launcher/modules/service/run_in_terminal.sh
+++ b/game-launcher/modules/service/run_in_terminal.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Run a command in the user's default terminal
+# Detects terminal from $TERMINAL env or common terminals
+
+detect_terminal() {
+    if [[ -n "$TERMINAL" ]]; then
+        echo "$TERMINAL"
+        return 0
+    fi
+
+    for term in kitty alacritty foot wezterm gnome-terminal konsole xterm \
+                xfce4-terminal terminator tilix lxterminal sakura urxvt st \
+                mate-terminal pantheon-terminal deepin-terminal guake tilda \
+                yakuake cool-retro-term; do
+        if command -v "$term" &>/dev/null; then
+            echo "$term"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+cmd="$*"
+
+if [[ -z "$cmd" ]]; then
+    echo "Usage: $0 <command>"
+    exit 1
+fi
+
+term=$(detect_terminal)
+
+if [[ -n "$term" ]]; then
+    case "$term" in
+        gnome-terminal)
+            "$term" -- "$SHELL" -c "$cmd"
+            ;;
+        yakuake)
+            qdbus org.kde.yakuake /yakuake/window org.kde.yakuake.toggleWindow 2>/dev/null || true
+            "$term" -e "$SHELL" -c "$cmd"
+            ;;
+        guake)
+            guake --show 2>/dev/null || true
+            "$term" -e "$SHELL" -c "$cmd"
+            ;;
+        *)
+            "$term" -e "$SHELL" -c "$cmd"
+            ;;
+    esac
+else
+    echo "Error: No terminal found. Please set \$TERMINAL or install a terminal." >&2
+    notify-send -u critical "Game Launcher" "No terminal found. Please set \$TERMINAL or install a terminal." 2>/dev/null || true
+    exit 1
+fi

--- a/game-launcher/toggle.sh
+++ b/game-launcher/toggle.sh
@@ -3,27 +3,13 @@
 # This script toggles the game launcher visibility
 
 LAUNCHER_DIR="$HOME/.config/quickshell/game-launcher"
-PID_FILE="$HOME/.cache/quickshell-game-launcher.pid"
 
-# Check if launcher is running
-if [ -f "$PID_FILE" ]; then
-    PID=$(cat "$PID_FILE")
-
-    # Check if process is actually running
-    if ps -p "$PID" > /dev/null 2>&1; then
-        # Kill the launcher
-        kill "$PID"
-        pkill -f "gamepad.py" || true
-        rm -f "$PID_FILE"
-        exit 0
-    else
-        # PID file exists but process is dead, clean up
-        rm -f "$PID_FILE"
-    fi
+# Check if launcher is running via pgrep
+if pgrep -f "^quickshell.*game-launcher" > /dev/null 2>&1; then
+    pkill -f "^quickshell.*game-launcher"
+    pkill -f "gamepad.py" 2>/dev/null || true
+    exit 0
 fi
 
-# Launch the game launcher with full path
+# Launch the game launcher
 quickshell -c "$LAUNCHER_DIR" &
-
-# Save PID
-echo $! > "$PID_FILE"


### PR DESCRIPTION
Follow-up to PR #6 — further fixes to toggle.sh and config portability.

**What was fixed**

- The PID file approach in toggle.sh was still unreliable because quickshell
  can fork/daemonize, making the stored PID point to a dead process.
  Next invocation would fail to detect the running instance and launch
  a duplicate. Replaced with pgrep/pkill and an anchored pattern that
  won't match the toggle script's own shell process.

- The "Game Library" entry in config.toml had a hardcoded path
  (/home/florian/...) and hardcoded terminal (kitty -e). Moved to a
  helper script (run_in_terminal.sh) that detects the user's terminal
  from $TERMINAL or searches 20+ common terminals. Falls back to
  stderr + notify-send warning if none is found.

- Translated Gamepad section in README from French to English and
  commented out the non-standard quickshell-game keybind example.

**Planned**

- Far future: Locale/language config for translatable UI strings.